### PR TITLE
Add vault selector to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17363,7 +17363,7 @@
     "id": "vault-selector",
     "name": "Vault Selector",
     "author": "tholms",
-    "description": "Automatically removes the 'open' property from vaults when Obsidian closes, allowing you to choose which vault to open each time.",
+    "description": "Automatically remove the 'open' property from the global json file on program exit, allowing you to choose which vault to open each time.",
     "repo": "tholms/VaultSelector"
 }
 ]

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -17358,5 +17358,12 @@
     "author": "ZigHolding",
     "description": "Sync notes or plugins between vaults.",
     "repo": "zigholding/obsidian-notesync-plugin"
-  }
+},
+{
+    "id": "vault-selector",
+    "name": "Vault Selector",
+    "author": "tholms",
+    "description": "Automatically removes the 'open' property from vaults when Obsidian closes, allowing you to choose which vault to open each time.",
+    "repo": "tholms/VaultSelector"
+}
 ]


### PR DESCRIPTION
Submitting new vault selector plugin to Obsidian community plugins.

# I am submitting a new Community Plugin

## Repo URL

Link to my plugin:
https://github.com/tholms/VaultSelector

## Release Checklist
- [x] I have tested the plugin on
  - [x]  Windows
  - [ ]  macOS
  - [ ]  Linux
- [x] My GitHub release contains all required files (as individual files, not just in the source.zip / source.tar.gz)
  - [x] `main.js`
  - [x] `manifest.json`
  - [x] `styles.css` _(optional)_
- [x] GitHub release name matches the exact version number specified in my manifest.json (_**Note:** Use the exact version number, don't include a prefix `v`_)
- [x] The `id` in my `manifest.json` matches the `id` in the `community-plugins.json` file.
- [x] My README.md describes the plugin's purpose and provides clear usage instructions.
- [x] I have read the developer policies at https://docs.obsidian.md/Developer+policies, and have assessed my plugins's adherence to these policies.
- [x] I have read the tips in https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines and have self-reviewed my plugin to avoid these common pitfalls.
- [x] I have added a license in the LICENSE file.
- [x] My project respects and is compatible with the original license of any code from other plugins that I'm using.
      I have given proper attribution to these other projects in my `README.md`.
